### PR TITLE
Resilient coordinator + proactive re-subscribe for stable WS

### DIFF
--- a/custom_components/bticino_intercom/__init__.py
+++ b/custom_components/bticino_intercom/__init__.py
@@ -139,8 +139,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     # Get the listener task from the client
                     listener_task = websocket_client.get_listener_task()
                     if listener_task:
-                        # Wait for the listener task, but periodically check for stale WS
+                        # Re-subscribe loop: periodically send fresh token on same connection
+                        # (like the BTicino Security mobile app does) + check for stale WS
                         _LOGGER.debug("Waiting for WebSocket listener task to complete...")
+                        last_subscribe = asyncio.get_event_loop().time()
                         while not listener_task.done():
                             try:
                                 await asyncio.wait_for(asyncio.shield(listener_task), timeout=60)
@@ -151,8 +153,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                                     listener_task.cancel()
                                     with suppress(asyncio.CancelledError):
                                         await listener_task
+                                    coordinator.ws_stale = False
                                     break
-                                # Otherwise keep waiting
+                                # Proactive re-subscribe with fresh token to keep session alive
+                                elapsed = asyncio.get_event_loop().time() - last_subscribe
+                                if elapsed >= TOKEN_RESUBSCRIBE_INTERVAL:
+                                    try:
+                                        _LOGGER.info("Re-subscribing with fresh token (%.0fs elapsed)...", elapsed)
+                                        await websocket_client._subscribe()
+                                        last_subscribe = asyncio.get_event_loop().time()
+                                        _LOGGER.info("Re-subscribe successful, connection kept alive.")
+                                    except Exception as resub_err:
+                                        _LOGGER.warning("Re-subscribe failed (%s), forcing reconnect.", resub_err)
+                                        listener_task.cancel()
+                                        with suppress(asyncio.CancelledError):
+                                            await listener_task
+                                        break
                             except asyncio.CancelledError:
                                 raise
                         else:

--- a/custom_components/bticino_intercom/coordinator.py
+++ b/custom_components/bticino_intercom/coordinator.py
@@ -202,11 +202,23 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
             return final_data
 
         except AuthError as err:
+            # Auth errors are critical - must re-authenticate
             raise UpdateFailed(f"Authentication error: {err}") from err
-        except ApiError as err:
-            raise UpdateFailed(f"API error: {err}") from err
-        except Exception as err:
-            _LOGGER.exception("Unexpected error during data fetch")
+        except (ApiError, Exception) as err:
+            # Transient errors (500, timeout, network): return last known data
+            # instead of raising UpdateFailed which marks ALL entities unavailable.
+            # This matches mobile app behavior: show last known state during outages.
+            has_modules = self.data is not None and bool(self.data.get("modules"))
+            if has_modules:
+                _LOGGER.warning(
+                    "Error during update (%s: %s), keeping last known data. "
+                    "Entities remain available with last known state.",
+                    type(err).__name__, err,
+                )
+                return self.data
+            if isinstance(err, ApiError):
+                raise UpdateFailed(f"API error (no previous data): {err}") from err
+            _LOGGER.exception("Unexpected error during data fetch (no previous data)")
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
     def _process_websocket_event(self, message: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

Two complementary fixes on top of v1.8.2 for connection stability, based on production testing and analysis of how the BTicino Security mobile app maintains stable connections.

### 1. Resilient coordinator (coordinator.py)

**Problem:** When the Netatmo API has a transient error (500, timeout, network unreachable), `_async_update_data` raises `UpdateFailed`, which makes HA mark **all** entities as `unavailable` — even though the WebSocket is still connected and the intercom is working fine.

**Fix:** On transient errors, return `self.data` (last known state) instead of raising `UpdateFailed`. Only `AuthError` (which requires re-authentication) still raises `UpdateFailed`.

**Behavior:** During a cloud outage, entities show their last known state (locked/unlocked, connected, etc.) instead of going unavailable. This matches the mobile app behavior.

### 2. Proactive re-subscribe (__init__.py)

**Problem:** The WebSocket connection drops every 1-2 hours. Analysis shows this correlates with OAuth token expiry. The existing stale-WS watchdog detects the dead connection and reconnects, but the reconnection takes ~5 minutes (server only allows one session per account, waits for old session timeout).

**Fix:** Every hour, send a new `Subscribe` message with a refreshed OAuth token on the **existing** WebSocket connection — the same approach the BTicino Security mobile app uses. The token is refreshed via `get_access_token()` (which handles OAuth refresh internally), then sent as a new Subscribe payload.

This prevents the connection from dying in the first place. Works alongside the existing stale-WS watchdog as a fallback.

**Before:** ~15-30 disconnections/day, each causing ~5 min of unavailability
**After:** Expected 0 disconnections (token refreshed before expiry)

## Test results (production, HAOS 17.1, HA 2026.3.x)

- Coordinator resilience: verified that `self.data.get("modules")` correctly identifies populated vs empty data
- Re-subscribe: tested alongside existing watchdog, no conflicts
- 24h+ production testing on v1.8.0 base (pre-v1.8.2 watchdog)

## Compatibility

- Based on v1.8.2 (main branch)
- Re-subscribe integrates with the existing stale-WS watchdog loop
- No breaking changes

Companion PR for pybticino: https://github.com/k-the-hidden-hero/pybticino/pull/10