### PR TITLE
fix: quality improvements — diagnostics, reauth, tests, quality scale

### DIFF
--- a/custom_components/bticino_intercom/config_flow.py
+++ b/custom_components/bticino_intercom/config_flow.py
@@ -88,7 +88,49 @@ class BticinoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle reauth when credentials expire."""
-        return self.async_abort(reason="reauth_not_supported")
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle reauth confirmation step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await validate_input(
+                    self.hass,
+                    {
+                        CONF_USERNAME: self._reauth_entry.data[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+            except AuthError:
+                errors["base"] = "invalid_auth"
+            except ApiError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during reauth")
+                errors["base"] = "unknown"
+
+            if not errors:
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry,
+                    data={
+                        **self._reauth_entry.data,
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            errors=errors,
+            description_placeholders={
+                "username": self._reauth_entry.data[CONF_USERNAME],
+            },
+        )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step."""

--- a/custom_components/bticino_intercom/diagnostics.py
+++ b/custom_components/bticino_intercom/diagnostics.py
@@ -1,0 +1,26 @@
+"""Diagnostics support for BTicino Intercom."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+REDACT_CONFIG = {CONF_USERNAME, CONF_PASSWORD}
+REDACT_COORDINATOR = {"access_token", "refresh_token", "local_ipv4", "id"}
+
+
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    return {
+        "config_entry": async_redact_data(entry.as_dict(), REDACT_CONFIG),
+        "coordinator_data": async_redact_data(
+            coordinator.data if coordinator.data else {},
+            REDACT_COORDINATOR,
+        ),
+    }

--- a/custom_components/bticino_intercom/manifest.json
+++ b/custom_components/bticino_intercom/manifest.json
@@ -3,7 +3,7 @@
   "name": "BTicino Classe 100X/300X",
   "codeowners": ["@k-the-hidden-hero"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["diagnostics"],
   "documentation": "https://github.com/k-the-hidden-hero/bticino_intercom",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/k-the-hidden-hero/bticino_intercom/issues",

--- a/custom_components/bticino_intercom/quality_scale.yaml
+++ b/custom_components/bticino_intercom/quality_scale.yaml
@@ -1,0 +1,106 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration does not register custom actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage:
+    status: todo
+    comment: Config flow tests not yet comprehensive.
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: No custom actions.
+  docs-high-level-description:
+    status: todo
+    comment: README exists but not in HA docs format.
+  docs-installation-instructions:
+    status: todo
+    comment: README has HACS installation instructions.
+  docs-removal-instructions:
+    status: todo
+    comment: Standard HA removal, not yet documented.
+  entity-event-setup:
+    status: exempt
+    comment: No event entities.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data:
+    status: todo
+    comment: Uses hass.data dict pattern instead of runtime_data.
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: No custom actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: todo
+    comment: light_as_lock option not documented in HA format.
+  docs-troubleshooting:
+    status: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage:
+    status: todo
+    comment: Partial test coverage, expanding.
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery:
+    status: exempt
+    comment: Cloud-only integration, no local discovery.
+  discovery-update-info:
+    status: exempt
+    comment: Cloud-only integration.
+  docs-data-update:
+    status: todo
+  docs-examples:
+    status: todo
+  docs-known-limitations:
+    status: todo
+  docs-supported-devices:
+    status: todo
+  docs-supported-functions:
+    status: todo
+  docs-use-cases:
+    status: todo
+  dynamic-devices:
+    status: exempt
+    comment: Devices are fixed per home topology.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: todo
+    comment: All entities enabled by default.
+  entity-translations: done
+  exception-translations:
+    status: todo
+  icon-translations:
+    status: todo
+  reconfigure-flow:
+    status: todo
+    comment: Not yet implemented.
+  repair-issues:
+    status: exempt
+    comment: No repair issues needed currently.
+  stale-devices:
+    status: exempt
+    comment: Devices are fixed per home topology.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing:
+    status: todo
+    comment: No py.typed marker or type stubs.

--- a/custom_components/bticino_intercom/strings.json
+++ b/custom_components/bticino_intercom/strings.json
@@ -9,6 +9,13 @@
           "password": "Password"
         }
       },
+      "reauth_confirm": {
+        "title": "Re-authenticate BTicino",
+        "description": "The credentials for {username} have expired. Please enter your password.",
+        "data": {
+          "password": "Password"
+        }
+      },
       "select_home": {
         "title": "Select BTicino Home",
         "description": "Multiple homes found for your account. Please select the home you want to add.",
@@ -24,7 +31,8 @@
     },
     "abort": {
       "already_configured": "Account is already configured.",
-      "no_homes_found": "No homes found for this BTicino account."
+      "no_homes_found": "No homes found for this BTicino account.",
+      "reauth_successful": "Re-authentication successful"
     }
   },
   "options": {

--- a/custom_components/bticino_intercom/translations/en.json
+++ b/custom_components/bticino_intercom/translations/en.json
@@ -9,6 +9,13 @@
           "password": "Password"
         }
       },
+      "reauth_confirm": {
+        "title": "Re-authenticate BTicino",
+        "description": "The credentials for {username} have expired. Please enter your password.",
+        "data": {
+          "password": "Password"
+        }
+      },
       "select_home": {
         "title": "Select BTicino Home",
         "description": "Multiple homes found for your account. Please select the home you want to add.",
@@ -24,7 +31,8 @@
     },
     "abort": {
       "already_configured": "Account is already configured.",
-      "no_homes_found": "No homes found for this BTicino account."
+      "no_homes_found": "No homes found for this BTicino account.",
+      "reauth_successful": "Re-authentication successful"
     }
   },
   "options": {

--- a/tests/test_token_persistence.py
+++ b/tests/test_token_persistence.py
@@ -1,0 +1,188 @@
+"""Tests for token persistence in BTicino integration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bticino_intercom.const import DOMAIN
+
+from .conftest import HOME_ID, HOME_NAME
+
+
+@pytest.fixture
+def mock_config_entry_for_tokens() -> MockConfigEntry:
+    """Return a mock config entry for token tests."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=HOME_NAME,
+        data={
+            "username": "user@example.com",
+            "password": "secret123",
+            "home_id": HOME_ID,
+        },
+        options={"light_as_lock": False},
+        unique_id="user@example.com",
+        version=1,
+    )
+
+
+@pytest.fixture
+def mock_token_store() -> MagicMock:
+    """Return a mock Store instance for token persistence."""
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+    store.async_remove = AsyncMock()
+    return store
+
+
+async def test_tokens_saved_after_auth(
+    hass: HomeAssistant,
+    mock_config_entry_for_tokens: MockConfigEntry,
+    mock_account: AsyncMock,
+    mock_websocket_client: MagicMock,
+    mock_token_store: MagicMock,
+) -> None:
+    """Verify that after setup, when AuthHandler authenticates, the token_callback saves tokens to Store."""
+    captured_callback = None
+    mock_auth = MagicMock()
+    mock_auth.get_access_token = AsyncMock(return_value="mock-access-token")
+    mock_auth.close_session = AsyncMock()
+    mock_auth.set_tokens = MagicMock()
+
+    def auth_factory(*args, **kwargs):
+        nonlocal captured_callback
+        captured_callback = kwargs.get("token_callback")
+        return mock_auth
+
+    with (
+        patch("custom_components.bticino_intercom.Store", return_value=mock_token_store),
+        patch("custom_components.bticino_intercom.AuthHandler", side_effect=auth_factory),
+    ):
+        mock_config_entry_for_tokens.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(mock_config_entry_for_tokens.entry_id)
+        await hass.async_block_till_done()
+
+    # Verify the callback was captured
+    assert captured_callback is not None
+
+    # Simulate AuthHandler calling the callback with token data
+    token_data = {
+        "access_token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "expires_at": 1700100000,
+    }
+    await captured_callback(token_data)
+
+    # Verify tokens were saved to the store
+    mock_token_store.async_save.assert_awaited_once_with(token_data)
+
+
+async def test_tokens_restored_on_setup(
+    hass: HomeAssistant,
+    mock_config_entry_for_tokens: MockConfigEntry,
+    mock_account: AsyncMock,
+    mock_websocket_client: MagicMock,
+    mock_token_store: MagicMock,
+) -> None:
+    """Verify that when Store has saved tokens, set_tokens is called on the AuthHandler before get_access_token."""
+    saved_tokens = {
+        "access_token": "saved-access-token",
+        "refresh_token": "saved-refresh-token",
+        "expires_at": 1700100000,
+    }
+    mock_token_store.async_load = AsyncMock(return_value=saved_tokens)
+
+    mock_auth = MagicMock()
+    mock_auth.close_session = AsyncMock()
+    mock_auth.set_tokens = MagicMock()
+
+    # Track call order
+    call_order = []
+    mock_auth.set_tokens.side_effect = lambda **kwargs: call_order.append("set_tokens")
+
+    async def track_get_access_token():
+        call_order.append("get_access_token")
+        return "mock-access-token"
+
+    mock_auth.get_access_token = AsyncMock(side_effect=track_get_access_token)
+
+    with (
+        patch("custom_components.bticino_intercom.Store", return_value=mock_token_store),
+        patch("custom_components.bticino_intercom.AuthHandler", return_value=mock_auth),
+    ):
+        mock_config_entry_for_tokens.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(mock_config_entry_for_tokens.entry_id)
+        await hass.async_block_till_done()
+
+    # Verify set_tokens was called with the saved token data
+    mock_auth.set_tokens.assert_called_once_with(
+        access_token="saved-access-token",
+        refresh_token="saved-refresh-token",
+        expires_at=1700100000,
+    )
+
+    # Verify set_tokens was called BEFORE get_access_token
+    assert call_order.index("set_tokens") < call_order.index("get_access_token")
+
+
+async def test_setup_works_without_saved_tokens(
+    hass: HomeAssistant,
+    mock_config_entry_for_tokens: MockConfigEntry,
+    mock_account: AsyncMock,
+    mock_websocket_client: MagicMock,
+    mock_token_store: MagicMock,
+) -> None:
+    """Verify that first-time setup (no stored tokens) still works with full auth."""
+    # async_load returns None (no saved tokens)
+    mock_token_store.async_load = AsyncMock(return_value=None)
+
+    mock_auth = MagicMock()
+    mock_auth.get_access_token = AsyncMock(return_value="mock-access-token")
+    mock_auth.close_session = AsyncMock()
+    mock_auth.set_tokens = MagicMock()
+
+    with (
+        patch("custom_components.bticino_intercom.Store", return_value=mock_token_store),
+        patch("custom_components.bticino_intercom.AuthHandler", return_value=mock_auth),
+    ):
+        mock_config_entry_for_tokens.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(mock_config_entry_for_tokens.entry_id)
+        await hass.async_block_till_done()
+
+    # set_tokens should NOT have been called (no saved tokens)
+    mock_auth.set_tokens.assert_not_called()
+
+    # get_access_token should still be called for full auth
+    mock_auth.get_access_token.assert_awaited()
+
+
+async def test_tokens_cleaned_on_remove(
+    hass: HomeAssistant,
+    mock_config_entry_for_tokens: MockConfigEntry,
+    mock_account: AsyncMock,
+    mock_websocket_client: MagicMock,
+    mock_token_store: MagicMock,
+) -> None:
+    """Verify that async_remove_entry calls store.async_remove()."""
+    mock_auth = MagicMock()
+    mock_auth.get_access_token = AsyncMock(return_value="mock-access-token")
+    mock_auth.close_session = AsyncMock()
+    mock_auth.set_tokens = MagicMock()
+
+    with (
+        patch("custom_components.bticino_intercom.Store", return_value=mock_token_store),
+        patch("custom_components.bticino_intercom.AuthHandler", return_value=mock_auth),
+    ):
+        mock_config_entry_for_tokens.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(mock_config_entry_for_tokens.entry_id)
+        await hass.async_block_till_done()
+
+        # Now remove the entry
+        await hass.config_entries.async_remove(mock_config_entry_for_tokens.entry_id)
+        await hass.async_block_till_done()
+
+    # Verify async_remove was called on the store
+    mock_token_store.async_remove.assert_awaited_once()


### PR DESCRIPTION
## Summary
- **Diagnostics endpoint** — `diagnostics.py` with redacted config/coordinator data export, added `diagnostics` dependency to manifest
- **Reauth flow** — proper `async_step_reauth_confirm` with password-only form, replacing the stub that aborted with "reauth_not_supported"
- **Quality scale** — `quality_scale.yaml` declaring compliance with HA integration quality standards
- **Token persistence tests** — 4 tests verifying save/restore/cleanup of OAuth tokens across restarts
- **Branch cleanup** — removed stale remote branches (fix/duplicate-entity-ids, fix/snapshot-unavailable, fix/token-persistence)

## Test plan
- [x] 92 tests pass (including 4 new token persistence tests)
- [x] Python syntax validated on all modified files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)