### PR TITLE
feat: real-time snapshot/vignette from incoming_call push

### DIFF
--- a/custom_components/bticino_intercom/coordinator.py
+++ b/custom_components/bticino_intercom/coordinator.py
@@ -226,10 +226,58 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
             _LOGGER.exception("Unexpected error during data fetch")
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
+    def _process_incoming_call_push(self, extra_params: dict[str, Any]) -> bool:
+        """Process incoming_call push to extract snapshot/vignette URLs.
+
+        The BNC1-incoming_call push delivers snapshot and vignette URLs
+        directly in extra_params, outside of the RTC signaling path.
+        Convert them into the subevent format the camera entities expect.
+        """
+        snapshot_url = extra_params.get("snapshot_url")
+        vignette_url = extra_params.get("vignette_url")
+        device_id = extra_params.get("device_id")
+
+        if not snapshot_url and not vignette_url:
+            _LOGGER.debug("incoming_call push without snapshot/vignette URLs, ignoring")
+            return False
+
+        now_ts = int(datetime.now(UTC).timestamp())
+        subevent: dict[str, Any] = {"time": now_ts}
+        if snapshot_url:
+            subevent["snapshot"] = {"url": snapshot_url}
+        if vignette_url:
+            subevent["vignette"] = {"url": vignette_url}
+
+        last_event = self.data.get(DATA_LAST_EVENT, {})
+        if last_event and last_event.get("type") == EVENT_TYPE_INCOMING_CALL:
+            # RTC call event already exists — enrich it with image URLs
+            last_event["subevents"] = [subevent]
+            _LOGGER.info("Enriched existing call event with snapshot/vignette from incoming_call push")
+        else:
+            # incoming_call arrived first (or standalone) — create a new entry
+            device_name = self.data.get("modules", {}).get(device_id, {}).get("name", device_id)
+            self.data[DATA_LAST_EVENT] = {
+                "type": EVENT_TYPE_INCOMING_CALL,
+                "timestamp": datetime.now(UTC),
+                "time": now_ts,
+                "module_id": device_id,
+                "module_name": device_name,
+                "subevents": [subevent],
+            }
+            _LOGGER.info("Created call event from incoming_call push with snapshot/vignette URLs")
+
+        return True
+
     def _process_websocket_event(self, message: dict[str, Any]) -> bool:
         """Process event data from websocket and update self.data."""
         updated = False
         extra_params = message.get("extra_params", {})
+
+        # --- Handle incoming_call push (snapshot/vignette delivery) ---
+        push_type = message.get("push_type", "")
+        if push_type.endswith("-incoming_call") or message.get("category") == "incoming_call":
+            return self._process_incoming_call_push(extra_params)
+
         session_data = extra_params.get("data", {}).get("session_description", {})
 
         # Extract module/device ID - prioritize specific module from call, fallback to device_id
@@ -330,6 +378,13 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
                 # Extract subevents from the original message if available
                 # session_data was already extracted: extra_params.get("data", {}).get("session_description", {})
                 subevents_data = session_data.get("subevents")
+
+                # If the RTC event has no image subevents, preserve any that
+                # were already stored by an earlier incoming_call push.
+                if not subevents_data:
+                    existing = self.data.get(DATA_LAST_EVENT, {}).get("subevents")
+                    if existing:
+                        subevents_data = existing
 
                 # Update last event data
                 self.data[DATA_LAST_EVENT] = {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -347,3 +347,196 @@ async def test_coordinator_fires_logbook_events(
 
     assert len(fired_events) == 1
     assert fired_events[0].data["module_id"] == EXT_UNIT_MODULE_ID
+
+
+# --- incoming_call push (snapshot/vignette) tests ---
+
+
+async def test_incoming_call_push_updates_last_event_with_snapshot(
+    hass: HomeAssistant,
+    mock_setup_entry: MockConfigEntry,
+) -> None:
+    """Test incoming_call push creates last_event with snapshot/vignette URLs."""
+    coordinator = hass.data[DOMAIN][mock_setup_entry.entry_id]["coordinator"]
+
+    message = {
+        "push_type": "BNC1-incoming_call",
+        "category": "incoming_call",
+        "extra_params": {
+            "event_type": "incoming_call",
+            "device_id": BRIDGE_MAC,
+            "home_id": HOME_ID,
+            "session_id": "sess_456",
+            "snapshot_url": "https://example.com/realtime_snapshot.jpg",
+            "vignette_url": "https://example.com/realtime_vignette.jpg",
+        },
+    }
+
+    updated = coordinator._process_websocket_event(message)
+
+    assert updated is True
+    last = coordinator.data[DATA_LAST_EVENT]
+    assert last["type"] == EVENT_TYPE_INCOMING_CALL
+    assert last["module_id"] == BRIDGE_MAC
+    assert len(last["subevents"]) == 1
+    assert last["subevents"][0]["snapshot"]["url"] == "https://example.com/realtime_snapshot.jpg"
+    assert last["subevents"][0]["vignette"]["url"] == "https://example.com/realtime_vignette.jpg"
+
+
+async def test_incoming_call_push_enriches_existing_rtc_event(
+    hass: HomeAssistant,
+    mock_setup_entry: MockConfigEntry,
+) -> None:
+    """Test incoming_call push enriches an existing RTC call event with image URLs."""
+    coordinator = hass.data[DOMAIN][mock_setup_entry.entry_id]["coordinator"]
+
+    # First: simulate RTC call event (no snapshot)
+    rtc_message = {
+        "extra_params": {
+            "device_id": EXT_UNIT_MODULE_ID,
+            "data": {
+                "session_description": {
+                    "type": "call",
+                    "module_id": EXT_UNIT_MODULE_ID,
+                    "session_id": "sess_789",
+                }
+            },
+        }
+    }
+    coordinator._process_websocket_event(rtc_message)
+
+    assert coordinator.data[DATA_LAST_EVENT]["type"] == EVENT_TYPE_INCOMING_CALL
+    assert not coordinator.data[DATA_LAST_EVENT].get("subevents")
+
+    # Then: incoming_call push arrives with snapshot
+    incoming_message = {
+        "push_type": "BNC1-incoming_call",
+        "category": "incoming_call",
+        "extra_params": {
+            "device_id": BRIDGE_MAC,
+            "snapshot_url": "https://example.com/snap.jpg",
+            "vignette_url": "https://example.com/vig.jpg",
+        },
+    }
+    updated = coordinator._process_websocket_event(incoming_message)
+
+    assert updated is True
+    last = coordinator.data[DATA_LAST_EVENT]
+    # Should still be the original call event, enriched
+    assert last["type"] == EVENT_TYPE_INCOMING_CALL
+    assert last["module_id"] == EXT_UNIT_MODULE_ID
+    assert last["subevents"][0]["snapshot"]["url"] == "https://example.com/snap.jpg"
+    assert last["subevents"][0]["vignette"]["url"] == "https://example.com/vig.jpg"
+
+
+async def test_incoming_call_push_without_urls_ignored(
+    hass: HomeAssistant,
+    mock_setup_entry: MockConfigEntry,
+) -> None:
+    """Test incoming_call push without snapshot/vignette URLs is ignored."""
+    coordinator = hass.data[DOMAIN][mock_setup_entry.entry_id]["coordinator"]
+
+    message = {
+        "push_type": "BNC1-incoming_call",
+        "category": "incoming_call",
+        "extra_params": {
+            "event_type": "incoming_call",
+            "device_id": BRIDGE_MAC,
+        },
+    }
+
+    updated = coordinator._process_websocket_event(message)
+
+    assert updated is False
+
+
+async def test_rtc_call_preserves_subevents_from_prior_incoming_call(
+    hass: HomeAssistant,
+    mock_setup_entry: MockConfigEntry,
+) -> None:
+    """Test RTC call event preserves snapshot subevents from a prior incoming_call push."""
+    coordinator = hass.data[DOMAIN][mock_setup_entry.entry_id]["coordinator"]
+
+    # First: incoming_call push arrives with snapshot
+    incoming_message = {
+        "push_type": "BNC1-incoming_call",
+        "category": "incoming_call",
+        "extra_params": {
+            "device_id": BRIDGE_MAC,
+            "snapshot_url": "https://example.com/early_snap.jpg",
+            "vignette_url": "https://example.com/early_vig.jpg",
+        },
+    }
+    coordinator._process_websocket_event(incoming_message)
+
+    # Then: RTC call event arrives (without subevents)
+    rtc_message = {
+        "extra_params": {
+            "device_id": EXT_UNIT_MODULE_ID,
+            "data": {
+                "session_description": {
+                    "type": "call",
+                    "module_id": EXT_UNIT_MODULE_ID,
+                    "session_id": "sess_abc",
+                }
+            },
+        }
+    }
+    coordinator._process_websocket_event(rtc_message)
+    await hass.async_block_till_done()
+
+    last = coordinator.data[DATA_LAST_EVENT]
+    assert last["type"] == EVENT_TYPE_INCOMING_CALL
+    assert last["module_id"] == EXT_UNIT_MODULE_ID
+    # Snapshot subevents from incoming_call should be preserved
+    assert last["subevents"][0]["snapshot"]["url"] == "https://example.com/early_snap.jpg"
+    assert last["subevents"][0]["vignette"]["url"] == "https://example.com/early_vig.jpg"
+
+
+async def test_incoming_call_push_only_snapshot(
+    hass: HomeAssistant,
+    mock_setup_entry: MockConfigEntry,
+) -> None:
+    """Test incoming_call push with only snapshot_url (no vignette)."""
+    coordinator = hass.data[DOMAIN][mock_setup_entry.entry_id]["coordinator"]
+
+    message = {
+        "push_type": "BNC1-incoming_call",
+        "category": "incoming_call",
+        "extra_params": {
+            "device_id": BRIDGE_MAC,
+            "snapshot_url": "https://example.com/only_snap.jpg",
+        },
+    }
+
+    updated = coordinator._process_websocket_event(message)
+
+    assert updated is True
+    last = coordinator.data[DATA_LAST_EVENT]
+    assert last["subevents"][0]["snapshot"]["url"] == "https://example.com/only_snap.jpg"
+    assert "vignette" not in last["subevents"][0]
+
+
+async def test_incoming_call_push_triggers_refresh(
+    hass: HomeAssistant,
+    mock_setup_entry: MockConfigEntry,
+) -> None:
+    """Test _handle_websocket_message triggers update for incoming_call push."""
+    coordinator = hass.data[DOMAIN][mock_setup_entry.entry_id]["coordinator"]
+
+    with (
+        patch.object(coordinator, "async_set_updated_data") as mock_set_data,
+        patch.object(coordinator, "async_request_refresh", new_callable=AsyncMock) as mock_refresh,
+    ):
+        message = {
+            "push_type": "BNC1-incoming_call",
+            "category": "incoming_call",
+            "extra_params": {
+                "device_id": BRIDGE_MAC,
+                "snapshot_url": "https://example.com/snap.jpg",
+            },
+        }
+        await coordinator._handle_websocket_message(message)
+
+        mock_set_data.assert_called_once()
+        mock_refresh.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Handle `BNC1-incoming_call` WebSocket push type in the coordinator to extract `snapshot_url`/`vignette_url` immediately, instead of waiting for the next poll cycle (~5 min)
- Convert the flat URL format from the push into the subevent structure the camera entities expect
- Handle both message orderings (RTC call first → incoming_call enriches; incoming_call first → RTC call preserves image subevents)

Closes #44 — reported by @marcob79 in https://github.com/k-the-hidden-hero/bticino_intercom/issues/39#issuecomment-4270010233

## Test plan

- [x] `test_incoming_call_push_updates_last_event_with_snapshot` — standalone incoming_call creates last_event with both URLs
- [x] `test_incoming_call_push_enriches_existing_rtc_event` — incoming_call after RTC call enriches existing event
- [x] `test_incoming_call_push_without_urls_ignored` — push without URLs is safely ignored
- [x] `test_rtc_call_preserves_subevents_from_prior_incoming_call` — RTC call after incoming_call preserves snapshot subevents
- [x] `test_incoming_call_push_only_snapshot` — push with only snapshot (no vignette) works
- [x] `test_incoming_call_push_triggers_refresh` — full message handler triggers `async_set_updated_data` + `async_request_refresh`
- [x] Full test suite: 97/97 passing, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)