### PR TITLE
Support BTicino Classe 300 EOS (BNCX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BTicino Classe 100X/300X Integration for Home Assistant
+# BTicino Classe 100X/300X/300 EOS Integration for Home Assistant
 
 [![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/v/release/k-the-hidden-hero/bticino_intercom)](https://github.com/k-the-hidden-hero/bticino_intercom/releases/latest)
@@ -6,7 +6,10 @@
 [![GitHub Issues](https://img.shields.io/github/issues/k-the-hidden-hero/bticino_intercom)](https://github.com/k-the-hidden-hero/bticino_intercom/issues)
 [![License](https://img.shields.io/github/license/k-the-hidden-hero/bticino_intercom)](LICENSE)
 
-A Home Assistant custom integration for **BTicino Classe 100X and 300X** video intercom systems. Monitor calls, control door locks, manage staircase lights, stream live video, and talk back — all from your Home Assistant dashboard.
+A Home Assistant custom integration for **BTicino Classe 100X, 300X and 300 EOS** video intercom systems. Monitor calls, control door locks, manage staircase lights, stream live video, and talk back — all from your Home Assistant dashboard.
+
+> [!NOTE]
+> **Classe 300 EOS support.** The newer Classe 300 EOS (bridge type **BNCX**) does not return a `variant` field on its modules — only the raw `type` (BNDL/BNEU/BNSL). The integration identifies modules by their canonical `type`, so the 300 EOS gets the same entities (camera, lock, light, doorbell) as the older models, with no extra configuration.
 
 Communicates with the BTicino/Netatmo cloud API via the [pybticino](https://github.com/k-the-hidden-hero/pybticino) library. Uses a persistent WebSocket connection for real-time call notifications and periodic polling for state synchronization.
 
@@ -345,7 +348,7 @@ When reporting a v2.0 bug:
 
 - Home Assistant 2026.3 or later
 - Home Assistant 2025.x or later (Python 3.13+)
-- A BTicino Classe 100X or 300X connected to the Netatmo cloud
+- A BTicino Classe 100X, 300X or 300 EOS connected to the Netatmo cloud
 - [pybticino](https://github.com/k-the-hidden-hero/pybticino) >= 1.7.1 (installed automatically)
 
 ---

--- a/custom_components/bticino_intercom/binary_sensor.py
+++ b/custom_components/bticino_intercom/binary_sensor.py
@@ -25,7 +25,7 @@ from .const import (
 )
 from .coordinator import BticinoIntercomCoordinator
 from .entity import BticinoEntity
-from .utils import cleanup_orphaned_entities, format_timestamp_iso
+from .utils import cleanup_orphaned_entities, format_timestamp_iso, resolve_module_subtype
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,35 +42,17 @@ async def async_setup_entry(
     if coordinator.data and "modules" in coordinator.data:
         _LOGGER.debug("Binary Sensor Setup: Found %d modules in coordinator data.", len(coordinator.data["modules"]))
         for module_id, module_data in coordinator.data["modules"].items():
-            variant = module_data.get("variant")
-            subtype = None
-            _LOGGER.debug("Binary Sensor Setup: Checking module %s, Variant: %s", module_id, variant)
-            if variant and ":" in variant:
-                try:
-                    subtype = variant.split(":", 1)[1]
-                    _LOGGER.debug("Binary Sensor Setup: Extracted subtype: %s", subtype)
-                except IndexError:
-                    _LOGGER.warning(
-                        "Could not parse subtype from variant '%s' for module %s",
-                        variant,
-                        module_id,
-                    )
-                    subtype = None
+            subtype = resolve_module_subtype(module_data)
+            _LOGGER.debug("Binary Sensor Setup: Checking module %s, subtype: %s", module_id, subtype)
 
             if subtype == SUBTYPE_EXTERNAL_UNIT:
-                _LOGGER.debug("Found external unit module (via variant subtype): %s", module_id)
+                _LOGGER.debug("Found external unit module: %s", module_id)
                 entities.append(BticinoCallBinarySensor(coordinator, module_id))
             elif subtype:
                 _LOGGER.debug(
                     "Binary Sensor Setup: Module %s subtype '%s' did not match expected external unit subtype.",
                     module_id,
                     subtype,
-                )
-            elif not subtype and variant is not None:
-                _LOGGER.debug(
-                    "Binary Sensor Setup: Module %s has variant '%s' but failed to extract subtype.",
-                    module_id,
-                    variant,
                 )
 
     # Add bridge "busy" sensor if bridge is available
@@ -103,14 +85,7 @@ class BticinoCallBinarySensor(BticinoEntity, BinarySensorEntity):
 
         if self._bridge_id:
             for other_module_id, other_module_data in coordinator.data.get("modules", {}).items():
-                other_variant = other_module_data.get("variant")
-                other_subtype = None
-                if other_variant and ":" in other_variant:
-                    try:
-                        other_subtype = other_variant.split(":", 1)[1]
-                    except IndexError:
-                        other_subtype = None
-
+                other_subtype = resolve_module_subtype(other_module_data)
                 if other_module_data.get("bridge") == self._bridge_id and other_subtype == SUBTYPE_DOORLOCK:
                     self._associated_lock_ids.append(other_module_id)
                     found_locks_data.append(other_module_data)

--- a/custom_components/bticino_intercom/camera.py
+++ b/custom_components/bticino_intercom/camera.py
@@ -22,9 +22,9 @@ from homeassistant.util.dt import utc_from_timestamp, utcnow
 from pybticino import AsyncAccount, SignalingClient
 from webrtc_models import RTCConfiguration, RTCIceCandidateInit, RTCIceServer
 
-from .const import DOMAIN, IMAGE_CACHE_SECONDS
+from .const import DOMAIN, IMAGE_CACHE_SECONDS, SUBTYPE_EXTERNAL_UNIT
 from .coordinator import BticinoIntercomCoordinator
-from .utils import cleanup_orphaned_entities, format_timestamp_iso
+from .utils import cleanup_orphaned_entities, format_timestamp_iso, resolve_module_subtype
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,8 +55,7 @@ async def async_setup_entry(
 
     # Create one WebRTC camera per external unit (BNEU module)
     for mid, mdata in coordinator.data.get("modules", {}).items():
-        variant = mdata.get("variant", "")
-        if "bneu_external_unit" in variant:
+        if resolve_module_subtype(mdata) == SUBTYPE_EXTERNAL_UNIT:
             entities.append(
                 BticinoWebRTCCamera(
                     coordinator,

--- a/custom_components/bticino_intercom/const.py
+++ b/custom_components/bticino_intercom/const.py
@@ -39,6 +39,21 @@ SUBTYPE_TO_PLATFORM = {
     SUBTYPE_EXTERNAL_UNIT: Platform.BINARY_SENSOR,  # Assuming external unit acts as a doorbell sensor
 }
 
+# The raw module "type" is the canonical, always-present discriminator. It is
+# returned for both the Classe 100X/300X and the Classe 300 EOS (bridge BNCX),
+# whereas the verbose "variant" field is only present on the older models. We map
+# the type directly so a single code path covers every device family.
+TYPE_TO_SUBTYPE = {
+    "BNDL": SUBTYPE_DOORLOCK,
+    "BNSL": SUBTYPE_STAIRCASE_LIGHT,
+    "BNEU": SUBTYPE_EXTERNAL_UNIT,
+}
+
+# Subtypes already handled by the integration. A "variant" carrying a subtype
+# outside this set is treated as a newer Netatmo variant and then takes
+# precedence over the type-derived value (forward-compat override).
+KNOWN_SUBTYPES = frozenset(SUBTYPE_TO_PLATFORM)
+
 
 # Push types from websocket
 PUSH_TYPE_RTC = "rtc"  # Base type for RTC events

--- a/custom_components/bticino_intercom/event.py
+++ b/custom_components/bticino_intercom/event.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, SIGNAL_CALL_RECEIVED, SUBTYPE_EXTERNAL_UNIT
 from .coordinator import BticinoIntercomCoordinator
 from .entity import BticinoEntity
-from .utils import cleanup_orphaned_entities
+from .utils import cleanup_orphaned_entities, resolve_module_subtype
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,9 +28,7 @@ async def async_setup_entry(
     entities = []
     if coordinator.data and "modules" in coordinator.data:
         for module_id, module_data in coordinator.data["modules"].items():
-            variant = module_data.get("variant", "")
-            subtype = variant.split(":", 1)[1] if ":" in variant else None
-            if subtype == SUBTYPE_EXTERNAL_UNIT:
+            if resolve_module_subtype(module_data) == SUBTYPE_EXTERNAL_UNIT:
                 entities.append(BticinoDoorbellEvent(coordinator, module_id))
 
     cleanup_orphaned_entities(hass, entry.entry_id, "event", entities)

--- a/custom_components/bticino_intercom/light.py
+++ b/custom_components/bticino_intercom/light.py
@@ -14,7 +14,7 @@ from .const import (
 )
 from .coordinator import BticinoIntercomCoordinator
 from .entity import BticinoEntity
-from .utils import cleanup_orphaned_entities, format_timestamp_iso
+from .utils import cleanup_orphaned_entities, format_timestamp_iso, resolve_module_subtype
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,39 +33,23 @@ async def async_setup_entry(
     if coordinator.data and "modules" in coordinator.data:
         _LOGGER.debug("Light Setup: Found %d modules in coordinator data.", len(coordinator.data["modules"]))
         for module_id, module_data in coordinator.data["modules"].items():
-            variant = module_data.get("variant")
-            subtype = None
-            _LOGGER.debug("Light Setup: Checking module %s, Variant: %s", module_id, variant)
-            if variant and ":" in variant:
-                try:
-                    subtype = variant.split(":", 1)[1]
-                    _LOGGER.debug("Light Setup: Extracted subtype: %s", subtype)
-                except IndexError:
-                    _LOGGER.warning(
-                        "Could not parse subtype from variant '%s' for module %s",
-                        variant,
-                        module_id,
-                    )
-                    subtype = None
+            subtype = resolve_module_subtype(module_data)
+            _LOGGER.debug("Light Setup: Checking module %s, subtype: %s", module_id, subtype)
 
             if subtype == SUBTYPE_STAIRCASE_LIGHT and not light_as_lock:
                 _LOGGER.debug(
-                    "Found light module %s (via variant subtype), representing as standard light.",
+                    "Found light module %s, representing as standard light.",
                     module_id,
                 )
                 entities.append(BticinoLight(coordinator, module_id))
             elif subtype == SUBTYPE_STAIRCASE_LIGHT and light_as_lock:
                 _LOGGER.debug(
-                    "Found light module %s (via variant subtype), but configured as lock. Skipping light entity creation.",
+                    "Found light module %s, but configured as lock. Skipping light entity creation.",
                     module_id,
                 )
             elif subtype:
                 _LOGGER.debug(
                     "Light Setup: Module %s subtype '%s' did not match expected light subtype.", module_id, subtype
-                )
-            elif not subtype and variant is not None:
-                _LOGGER.debug(
-                    "Light Setup: Module %s has variant '%s' but failed to extract subtype.", module_id, variant
                 )
 
     if not entities:

--- a/custom_components/bticino_intercom/lock.py
+++ b/custom_components/bticino_intercom/lock.py
@@ -19,7 +19,7 @@ from .const import (
 )
 from .coordinator import BticinoIntercomCoordinator
 from .entity import BticinoEntity
-from .utils import cleanup_orphaned_entities, format_timestamp_iso
+from .utils import cleanup_orphaned_entities, format_timestamp_iso, resolve_module_subtype
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,33 +37,21 @@ async def async_setup_entry(
     if coordinator.data and "modules" in coordinator.data:
         _LOGGER.debug("Lock Setup: Found %d modules in coordinator data.", len(coordinator.data["modules"]))
         for module_id, module_data in coordinator.data["modules"].items():
-            variant = module_data.get("variant")
-            subtype = None
-            _LOGGER.debug("Lock Setup: Checking module %s, Variant: %s", module_id, variant)
-            if variant and ":" in variant:
-                try:
-                    subtype = variant.split(":", 1)[1]
-                    _LOGGER.debug("Lock Setup: Extracted subtype: %s", subtype)
-                except IndexError:
-                    _LOGGER.warning(
-                        "Could not parse subtype from variant '%s' for module %s",
-                        variant,
-                        module_id,
-                    )
-                    subtype = None
+            subtype = resolve_module_subtype(module_data)
+            _LOGGER.debug("Lock Setup: Checking module %s, subtype: %s", module_id, subtype)
 
             if subtype == SUBTYPE_DOORLOCK:
-                _LOGGER.debug("Found lock module (via variant subtype): %s", module_id)
+                _LOGGER.debug("Found lock module: %s", module_id)
                 entities.append(BticinoLock(coordinator, module_id))
             elif subtype == SUBTYPE_STAIRCASE_LIGHT and light_as_lock:
                 _LOGGER.debug(
-                    "Found light module %s (via variant subtype), representing as lock (light_as_lock=True).",
+                    "Found light module %s, representing as lock (light_as_lock=True).",
                     module_id,
                 )
                 entities.append(BticinoLightAsLock(coordinator, module_id))
             elif subtype == SUBTYPE_STAIRCASE_LIGHT and not light_as_lock:
                 _LOGGER.debug(
-                    "Found light module %s (via variant subtype), but configured as light. Skipping lock entity creation.",
+                    "Found light module %s, but configured as light. Skipping lock entity creation.",
                     module_id,
                 )
             elif subtype:
@@ -71,10 +59,6 @@ async def async_setup_entry(
                     "Lock Setup: Module %s subtype '%s' did not match expected lock/light subtypes.",
                     module_id,
                     subtype,
-                )
-            elif not subtype and variant is not None:
-                _LOGGER.debug(
-                    "Lock Setup: Module %s has variant '%s' but failed to extract subtype.", module_id, variant
                 )
 
     if not entities:

--- a/custom_components/bticino_intercom/manifest.json
+++ b/custom_components/bticino_intercom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bticino_intercom",
-  "name": "BTicino Classe 100X/300X",
+  "name": "BTicino Classe 100X/300X/300 EOS",
   "after_dependencies": ["media_source"],
   "codeowners": ["@k-the-hidden-hero"],
   "config_flow": true,
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/k-the-hidden-hero/bticino_intercom/issues",
   "loggers": ["pybticino"],
   "requirements": ["pybticino>=1.8.2"],
-  "version": "2.0.1"
+  "version": "2.1.0"
 }

--- a/custom_components/bticino_intercom/utils.py
+++ b/custom_components/bticino_intercom/utils.py
@@ -4,16 +4,39 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utc_from_timestamp
+
+from .const import KNOWN_SUBTYPES, TYPE_TO_SUBTYPE
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def resolve_module_subtype(module_data: dict[str, Any]) -> str | None:
+    """Return the canonical subtype for a module.
+
+    The raw ``type`` (BNDL/BNEU/BNSL) is always present and identifies the
+    module for the Classe 100X/300X and the Classe 300 EOS alike, so we map it
+    directly via ``TYPE_TO_SUBTYPE``.
+
+    The legacy ``variant`` field (``"<TYPE>:<subtype>"``, present only on the
+    older models) is consulted purely as a forward-compat override: if it
+    carries a subtype we do not yet know about, we honour it. A known variant is
+    redundant with ``type`` and adds nothing.
+    """
+    subtype = TYPE_TO_SUBTYPE.get(module_data.get("type", ""))
+    variant = module_data.get("variant")
+    if variant and ":" in variant:
+        variant_subtype = variant.split(":", 1)[1]
+        if variant_subtype and variant_subtype not in KNOWN_SUBTYPES:
+            return variant_subtype
+    return subtype
 
 
 def format_timestamp_iso(timestamp: int | float | datetime | None) -> str | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,3 +429,114 @@ async def mock_setup_entry_light_as_lock(
         mock_websocket_client,
         mock_signaling_client,
     )
+
+
+# --- Classe 300 EOS fixtures (bridge BNCX, modules without 'variant') ---
+
+
+@pytest.fixture
+def mock_modules_data_eos() -> dict[str, Any]:
+    """Return EOS topology: bridge is BNCX and modules carry only 'type'.
+
+    Unlike the Classe 100X/300X, the Classe 300 EOS does not return a 'variant'
+    field for its modules — the raw 'type' (BNDL/BNEU/BNSL) is the only
+    discriminator available.
+    """
+    return {
+        BRIDGE_MAC: {
+            "id": BRIDGE_MAC,
+            "type": "BNCX",
+            "name": "BTicino 300 EOS",
+            "firmware_name": "2.1.0",
+            "reachable": True,
+            "uptime": 3600,
+            "wifi_strength": 70,
+            "websocket_connected": True,
+            "local_ipv4": "192.168.1.101",
+        },
+        EXTERNAL_UNIT_ID: {
+            "id": EXTERNAL_UNIT_ID,
+            "type": "BNEU",
+            "name": EXTERNAL_UNIT_NAME,
+            "reachable": True,
+            "bridge": BRIDGE_MAC,
+        },
+        DOORLOCK_ID: {
+            "id": DOORLOCK_ID,
+            "type": "BNDL",
+            "name": "Porta Esterna",
+            "reachable": True,
+            "bridge": BRIDGE_MAC,
+        },
+        STAIRCASE_LIGHT_ID: {
+            "id": STAIRCASE_LIGHT_ID,
+            "type": "BNSL",
+            "name": "Luci Scale",
+            "reachable": True,
+            "bridge": BRIDGE_MAC,
+        },
+    }
+
+
+@pytest.fixture
+def mock_account_eos(mock_modules_data_eos, mock_events_history) -> AsyncMock:
+    """Create a persistent mock AsyncAccount serving the EOS topology."""
+    mock_acct = AsyncMock()
+    mock_acct.homes = {
+        HOME_ID: MagicMock(
+            id=HOME_ID,
+            name="Test Home EOS",
+            raw_data={"name": "Test Home EOS", "id": HOME_ID},
+            modules=[MagicMock(id=mid, raw_data=mdata) for mid, mdata in mock_modules_data_eos.items()],
+        )
+    }
+    mock_acct.async_update_topology = AsyncMock()
+    mock_acct.async_get_home_status = AsyncMock(
+        return_value={
+            "body": {"home": {"modules": list(mock_modules_data_eos.values())}},
+        }
+    )
+    mock_acct.async_get_events = AsyncMock(
+        return_value={
+            "body": {"home": {"events": mock_events_history}},
+        }
+    )
+    mock_acct.async_get_turn_servers = AsyncMock(return_value=[])
+    mock_acct.async_set_module_state = AsyncMock()
+    return mock_acct
+
+
+@pytest.fixture
+def mock_config_entry_eos() -> MockConfigEntry:
+    """Create a mock config entry for an EOS home."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="BTicino 300 EOS Test",
+        data={
+            "home_id": HOME_ID,
+            "username": "test@example.com",
+            "password": "testpass",
+        },
+        unique_id=f"{HOME_ID}_eos",
+    )
+
+
+@pytest.fixture
+async def mock_setup_entry_eos(
+    hass: HomeAssistant,
+    mock_config_entry_eos: MockConfigEntry,
+    mock_auth_handler: AsyncMock,
+    mock_account_eos: AsyncMock,
+    mock_websocket_client: AsyncMock,
+    mock_signaling_client: AsyncMock,
+    enable_custom_integrations: None,
+) -> MockConfigEntry:
+    """Set up the integration with an EOS (BNCX, no-variant) topology."""
+    return await _setup_integration(
+        hass,
+        mock_config_entry_eos,
+        mock_auth_handler,
+        mock_account_eos,
+        mock_websocket_client,
+        mock_signaling_client,
+    )

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -1,0 +1,57 @@
+"""Integration tests for the Classe 300 EOS (bridge BNCX, modules without 'variant').
+
+These verify that modules identified only by their raw 'type' (no 'variant'
+field) still produce the full set of entities — the gap the EOS support closes.
+"""
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .conftest import EXTERNAL_UNIT_ID
+
+
+async def test_eos_lock_created(hass: HomeAssistant, mock_setup_entry_eos: MockConfigEntry) -> None:
+    """A BNDL module without 'variant' still yields a lock entity."""
+    assert len(hass.states.async_entity_ids(LOCK_DOMAIN)) >= 1
+
+
+async def test_eos_light_created(hass: HomeAssistant, mock_setup_entry_eos: MockConfigEntry) -> None:
+    """A BNSL module without 'variant' still yields a light entity."""
+    assert len(hass.states.async_entity_ids(LIGHT_DOMAIN)) >= 1
+
+
+async def test_eos_binary_sensor_created(hass: HomeAssistant, mock_setup_entry_eos: MockConfigEntry) -> None:
+    """A BNEU module without 'variant' yields a *call* binary sensor.
+
+    Asserts the specific call-sensor entity rather than just a non-empty
+    binary_sensor domain — the bridge "busy" sensor is always created
+    (driven by the bridge MAC, not by the module subtype), so a bare count
+    would pass even without the EOS fix.
+    """
+    ent_reg = er.async_get(hass)
+    call_unique_id = f"{mock_setup_entry_eos.entry_id}_call_{EXTERNAL_UNIT_ID}"
+    entity_id = ent_reg.async_get_entity_id(BINARY_SENSOR_DOMAIN, "bticino_intercom", call_unique_id)
+    assert entity_id is not None
+
+
+async def test_eos_doorbell_event_created(hass: HomeAssistant, mock_setup_entry_eos: MockConfigEntry) -> None:
+    """A BNEU module without 'variant' yields a DOORBELL event entity.
+
+    This is the entity the original file-replacement patch failed to create on
+    EOS (it never updated event.py).
+    """
+    assert len(hass.states.async_entity_ids(EVENT_DOMAIN)) >= 1
+
+
+async def test_eos_webrtc_camera_created(hass: HomeAssistant, mock_setup_entry_eos: MockConfigEntry) -> None:
+    """A WebRTC camera is created for the BNEU external unit (no 'variant')."""
+    ent_reg = er.async_get(hass)
+    webrtc_unique_id = f"{mock_setup_entry_eos.entry_id}_webrtc_{EXTERNAL_UNIT_ID}"
+    entity_id = ent_reg.async_get_entity_id(CAMERA_DOMAIN, "bticino_intercom", webrtc_unique_id)
+    assert entity_id is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+"""Unit tests for the BTicino utility helpers."""
+
+import pytest
+
+from custom_components.bticino_intercom.const import (
+    SUBTYPE_DOORLOCK,
+    SUBTYPE_EXTERNAL_UNIT,
+    SUBTYPE_STAIRCASE_LIGHT,
+)
+from custom_components.bticino_intercom.utils import resolve_module_subtype
+
+
+@pytest.mark.parametrize(
+    ("module_data", "expected"),
+    [
+        # EOS (bridge BNCX): only the raw 'type' is present, no 'variant'.
+        ({"type": "BNDL"}, SUBTYPE_DOORLOCK),
+        ({"type": "BNSL"}, SUBTYPE_STAIRCASE_LIGHT),
+        ({"type": "BNEU"}, SUBTYPE_EXTERNAL_UNIT),
+        # Legacy 100X/300X: a redundant 'variant' yields the same subtype.
+        ({"type": "BNDL", "variant": "BNDL:bndl_doorlock"}, SUBTYPE_DOORLOCK),
+        ({"type": "BNSL", "variant": "BNSL:bnsl_staircase_light"}, SUBTYPE_STAIRCASE_LIGHT),
+        ({"type": "BNEU", "variant": "BNEU:bneu_external_unit"}, SUBTYPE_EXTERNAL_UNIT),
+        # Forward-compat override: an UNKNOWN variant subtype wins over the type.
+        ({"type": "BNEU", "variant": "BNEU:bneu_future_thing"}, "bneu_future_thing"),
+        # A malformed variant (no colon) is ignored — fall back to the type.
+        ({"type": "BNDL", "variant": "garbage"}, SUBTYPE_DOORLOCK),
+        # Bridge / unmapped type without a usable variant → None (no entity).
+        ({"type": "BNCX"}, None),
+        ({"type": "BNC1"}, None),
+        # Bridge with a legacy (unknown) variant → its own subtype, matched by
+        # no platform, so still no entity is created.
+        ({"type": "BNC1", "variant": "BNC1:bnc1_bridge"}, "bnc1_bridge"),
+        # Empty / missing data → None.
+        ({}, None),
+    ],
+)
+def test_resolve_module_subtype(module_data: dict, expected: str | None) -> None:
+    """The type is canonical; variant only overrides for unknown subtypes."""
+    assert resolve_module_subtype(module_data) == expected


### PR DESCRIPTION
The Classe 300 EOS reports its modules with only the raw `type` (BNDL/BNEU/BNSL) and no `variant` field. Every platform filtered entities on `variant`, so EOS systems got zero entities.

Resolve the module subtype from `type` instead the canonical, always-present discriminator shared by the 100X/300X and the 300 EOS. The verbose `variant` is now consulted only as a forward-compat override for subtypes we don't yet know about.

- add utils.resolve_module_subtype() as the single source of truth
- lock/light/binary_sensor/event/camera delegate to it, dropping the duplicated `variant.split(":")` parsing (also fixes event.py's Doorbell and the binary_sensor sibling-lock association)
- coordinator and pybticino need no change: the bridge is detected by its MAC-format id and WS events route by payload structure
- manifest: name -> 100X/300X/300 EOS, bump 2.0.1 -> 2.1.0
- docs: README mentions the 300 EOS
- tests: add test_eos.py + test_utils.py and EOS fixtures in conftest

Verified against a real Classe 300 EOS (firmware 4.00.12): bridge detected, all 3 peripherals classified by type, 15 entities on 1 device.