### PR TITLE
fix: improve WebSocket stability and error recovery

### DIFF
--- a/custom_components/bticino_intercom/__init__.py
+++ b/custom_components/bticino_intercom/__init__.py
@@ -44,6 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 RECONNECT_DELAY = 30  # Default delay, overridden by smart backoff
 BOOT_RETRY_DELAYS = [5, 10, 30, 30, 30, 60]  # Backoff al boot
 RUNTIME_RETRY_DELAYS = [5, 15, 30, 60, 120]  # Backoff durante vita normale
+MAX_CONSECUTIVE_WS_FAILURES = 5  # Force config entry reload after this many consecutive failures
 TOKEN_RESUBSCRIBE_INTERVAL = 3600  # Re-subscribe with fresh token every hour
 WEBSOCKET_TASK_KEY = "websocket_connection_task"
 WEBSOCKET_CLIENT_KEY = "websocket_client"
@@ -355,6 +356,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         "boot" if is_boot else "runtime",
                         delay,
                     )
+
+                    # After too many consecutive failures, force a full
+                    # config entry reload to reset all state cleanly.
+                    if not is_boot and attempt >= MAX_CONSECUTIVE_WS_FAILURES:
+                        _LOGGER.error(
+                            "WebSocket failed %d consecutive times, forcing config entry reload.",
+                            attempt,
+                        )
+                        hass.async_create_task(
+                            hass.config_entries.async_reload(entry.entry_id),
+                            f"{DOMAIN} auto-reload after WS failure",
+                        )
+                        break
+
                     try:
                         await asyncio.sleep(delay)
                     except asyncio.CancelledError:

--- a/custom_components/bticino_intercom/__init__.py
+++ b/custom_components/bticino_intercom/__init__.py
@@ -350,12 +350,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     delays = BOOT_RETRY_DELAYS if is_boot else RUNTIME_RETRY_DELAYS
                     delay = delays[min(attempt, len(delays) - 1)]
                     attempt += 1
-                    _LOGGER.info(
-                        "WebSocket reconnect attempt %d (%s), waiting %ds...",
-                        attempt,
-                        "boot" if is_boot else "runtime",
-                        delay,
-                    )
 
                     # After too many consecutive failures, force a full
                     # config entry reload to reset all state cleanly.
@@ -364,12 +358,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             "WebSocket failed %d consecutive times, forcing config entry reload.",
                             attempt,
                         )
-                        hass.async_create_task(
-                            hass.config_entries.async_reload(entry.entry_id),
-                            f"{DOMAIN} auto-reload after WS failure",
-                        )
+                        hass.config_entries.async_schedule_reload(entry.entry_id)
                         break
 
+                    _LOGGER.info(
+                        "WebSocket reconnect attempt %d (%s), waiting %ds...",
+                        attempt,
+                        "boot" if is_boot else "runtime",
+                        delay,
+                    )
                     try:
                         await asyncio.sleep(delay)
                     except asyncio.CancelledError:

--- a/custom_components/bticino_intercom/coordinator.py
+++ b/custom_components/bticino_intercom/coordinator.py
@@ -38,11 +38,12 @@ from .const import (
 )
 from .history import EventHistoryStore
 
-# WebSocket is considered stale if no message received for this many seconds.
-# The server sends periodic pings (every 20s) that count as messages in the
-# websockets library, so silence beyond this threshold means the connection
-# is likely dead but not yet detected by TCP keepalive.
-WS_STALE_THRESHOLD = 180  # 3 minutes (server pings every ~20s, so 9 missed pings)
+# WebSocket is considered stale if no application message has been received
+# for this many seconds.  Note: _last_ws_message_time only updates on data
+# frames reaching the message callback — protocol-level WS pings do not count.
+# 300s keeps detection reasonably fast without flagging quiet-but-healthy
+# connections during idle periods.
+WS_STALE_THRESHOLD = 300  # 5 minutes
 
 # After this many consecutive transient API failures, raise UpdateFailed
 # instead of returning stale data, so entities are properly marked unavailable.

--- a/custom_components/bticino_intercom/coordinator.py
+++ b/custom_components/bticino_intercom/coordinator.py
@@ -42,7 +42,11 @@ from .history import EventHistoryStore
 # The server sends periodic pings (every 20s) that count as messages in the
 # websockets library, so silence beyond this threshold means the connection
 # is likely dead but not yet detected by TCP keepalive.
-WS_STALE_THRESHOLD = 600  # 10 minutes
+WS_STALE_THRESHOLD = 180  # 3 minutes (server pings every ~20s, so 9 missed pings)
+
+# After this many consecutive transient API failures, raise UpdateFailed
+# instead of returning stale data, so entities are properly marked unavailable.
+MAX_CONSECUTIVE_TRANSIENT_ERRORS = 3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +87,7 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
         self._main_device_id = None
         self._last_ws_message_time: datetime | None = None
         self._ws_stale = False
+        self._consecutive_transient_errors = 0
         # Per-module active call sessions for retransmission dedup.
         # {"started": datetime, "last_seen": datetime,
         #  "watchdog": asyncio.Task | None,
@@ -231,19 +236,36 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
                     )
                     self._ws_stale = True
 
+            # Successful update: reset transient error counter
+            self._consecutive_transient_errors = 0
             return final_data
 
         except AuthError as err:
             # Auth errors are critical — must re-authenticate
             raise UpdateFailed(f"Authentication error: {err}") from err
         except (ApiError, TimeoutError, OSError, ConnectionError) as err:
-            # Transient errors: return last known data instead of marking
-            # all entities unavailable. Matches mobile app behavior.
+            self._consecutive_transient_errors += 1
+            # Transient errors: return last known data for the first few
+            # failures to avoid flapping.  After MAX_CONSECUTIVE_TRANSIENT_ERRORS
+            # in a row, raise UpdateFailed so entities are properly marked
+            # unavailable — the connection is likely dead at that point.
             if self.data and self.data.get("modules"):
+                if self._consecutive_transient_errors >= MAX_CONSECUTIVE_TRANSIENT_ERRORS:
+                    _LOGGER.error(
+                        "API has failed %d times consecutively (%s: %s), marking entities unavailable.",
+                        self._consecutive_transient_errors,
+                        type(err).__name__,
+                        err,
+                    )
+                    raise UpdateFailed(
+                        f"API error after {self._consecutive_transient_errors} consecutive failures: {err}"
+                    ) from err
                 _LOGGER.warning(
-                    "Transient error during update (%s: %s), keeping last known data.",
+                    "Transient error during update (%s: %s), keeping last known data (%d/%d).",
                     type(err).__name__,
                     err,
+                    self._consecutive_transient_errors,
+                    MAX_CONSECUTIVE_TRANSIENT_ERRORS,
                 )
                 return self.data
             raise UpdateFailed(f"API error (no previous data): {err}") from err

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,7 +6,10 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pybticino.exceptions import ApiError
 from pytest_homeassistant_custom_component.common import async_capture_events
 
 from custom_components.bticino_intercom.const import (
@@ -20,7 +23,10 @@ from custom_components.bticino_intercom.const import (
     EVENT_TYPE_TERMINATED,
     SIGNAL_CALL_RECEIVED,
 )
-from custom_components.bticino_intercom.coordinator import BticinoIntercomCoordinator
+from custom_components.bticino_intercom.coordinator import (
+    MAX_CONSECUTIVE_TRANSIENT_ERRORS,
+    BticinoIntercomCoordinator,
+)
 
 from .conftest import BRIDGE_MAC, EXTERNAL_UNIT_ID, SESSION_ID
 
@@ -702,3 +708,72 @@ class TestRtcTerminateDedup:
                 await coordinator._handle_websocket_message(ws_rtc_rescind)
 
         assert mock_refresh.call_count == 1
+
+
+# =============================================================================
+# Transient error tracking (consecutive API failures)
+# =============================================================================
+
+
+class TestTransientErrorTracking:
+    """Isolated transient errors return stale data; sustained failures must
+    raise UpdateFailed so entities are properly marked unavailable."""
+
+    async def test_isolated_transient_error_returns_stale_data(
+        self, coordinator: BticinoIntercomCoordinator
+    ) -> None:
+        """A single transient error keeps last known data (no UpdateFailed)."""
+        coordinator.account.async_update_topology.side_effect = ApiError(500, "Server down")
+
+        result = await coordinator._async_update_data()
+
+        assert result is coordinator.data
+        assert coordinator._consecutive_transient_errors == 1
+
+    async def test_consecutive_transient_errors_raise_update_failed(
+        self, coordinator: BticinoIntercomCoordinator
+    ) -> None:
+        """After MAX_CONSECUTIVE_TRANSIENT_ERRORS failures, UpdateFailed is raised."""
+        coordinator.account.async_update_topology.side_effect = ApiError(500, "Server down")
+
+        # The first N-1 failures degrade gracefully to stale data
+        for _ in range(MAX_CONSECUTIVE_TRANSIENT_ERRORS - 1):
+            result = await coordinator._async_update_data()
+            assert result is coordinator.data
+
+        # The Nth consecutive failure must surface as UpdateFailed
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    async def test_success_resets_transient_error_counter(
+        self, coordinator: BticinoIntercomCoordinator, mock_account: AsyncMock
+    ) -> None:
+        """A successful update resets the counter, re-arming graceful degradation."""
+        coordinator.account = mock_account
+
+        # Two failures bring the counter to the brink
+        mock_account.async_update_topology.side_effect = ApiError(500, "Server down")
+        for _ in range(MAX_CONSECUTIVE_TRANSIENT_ERRORS - 1):
+            await coordinator._async_update_data()
+        assert coordinator._consecutive_transient_errors == MAX_CONSECUTIVE_TRANSIENT_ERRORS - 1
+
+        # A successful update resets the counter
+        mock_account.async_update_topology.side_effect = None
+        await coordinator._async_update_data()
+        assert coordinator._consecutive_transient_errors == 0
+
+        # The next failure degrades gracefully again instead of raising
+        mock_account.async_update_topology.side_effect = ApiError(500, "Server down")
+        result = await coordinator._async_update_data()
+        assert result is coordinator.data
+        assert coordinator._consecutive_transient_errors == 1
+
+    async def test_transient_error_without_previous_data_raises(
+        self, coordinator: BticinoIntercomCoordinator
+    ) -> None:
+        """With no previous data to fall back on, even one failure raises."""
+        coordinator.data = {}
+        coordinator.account.async_update_topology.side_effect = ApiError(500, "Server down")
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -719,9 +719,7 @@ class TestTransientErrorTracking:
     """Isolated transient errors return stale data; sustained failures must
     raise UpdateFailed so entities are properly marked unavailable."""
 
-    async def test_isolated_transient_error_returns_stale_data(
-        self, coordinator: BticinoIntercomCoordinator
-    ) -> None:
+    async def test_isolated_transient_error_returns_stale_data(self, coordinator: BticinoIntercomCoordinator) -> None:
         """A single transient error keeps last known data (no UpdateFailed)."""
         coordinator.account.async_update_topology.side_effect = ApiError(500, "Server down")
 
@@ -768,9 +766,7 @@ class TestTransientErrorTracking:
         assert result is coordinator.data
         assert coordinator._consecutive_transient_errors == 1
 
-    async def test_transient_error_without_previous_data_raises(
-        self, coordinator: BticinoIntercomCoordinator
-    ) -> None:
+    async def test_transient_error_without_previous_data_raises(self, coordinator: BticinoIntercomCoordinator) -> None:
         """With no previous data to fall back on, even one failure raises."""
         coordinator.data = {}
         coordinator.account.async_update_topology.side_effect = ApiError(500, "Server down")


### PR DESCRIPTION
## Summary

Addresses #63 — chronic WebSocket instability causing lock entities to become unavailable.

Three targeted changes:

- **Reduce `WS_STALE_THRESHOLD` from 600s to 180s** — the Netatmo server pings every ~20s, so 3 minutes (9 missed pings) is sufficient to detect a dead connection vs the current 10 minutes
- **Track consecutive transient API failures** in coordinator — after 3 consecutive failures, raise `UpdateFailed` instead of returning stale data forever. This properly marks entities as unavailable, making the problem visible in HA. Isolated transient errors still return stale data gracefully (1-2 failures)
- **Auto-reload config entry after 5 consecutive WebSocket reconnect failures** — instead of retrying forever in a broken state, force a full reset of auth tokens, coordinator, and WebSocket client

## Evidence

Real production logs showing 30 stale events in 24 hours, with the lock entity becoming unusable between reconnects. Full log excerpts in #63.

## Test plan

- [ ] Verify stale detection triggers after ~3 min of WS silence instead of ~10 min
- [ ] Verify entity goes unavailable after 3 consecutive API failures (simulate by blocking `app.netatmo.net`)
- [ ] Verify entity recovers after a successful API call resets the counter
- [ ] Verify config entry reload triggers after 5 consecutive WS reconnect failures
- [ ] Verify the reload doesn't trigger during boot (guarded by `not is_boot`)
- [ ] Existing CI (hassfest, HACS validation) passes