### PR TITLE
fix: never delete registered entities on empty/partial topology at startup

### DIFF
--- a/custom_components/bticino_intercom/coordinator.py
+++ b/custom_components/bticino_intercom/coordinator.py
@@ -135,13 +135,24 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
         try:
             await self.account.async_update_topology()
             if not self.account.homes:
-                _LOGGER.warning("No homes found for this account.")
-                return {
-                    "homes": {},
-                    "modules": {},
-                    "events_history": {},
-                    DATA_LAST_EVENT: {},
-                }
+                # An empty topology is a degraded cloud response, not a real
+                # "no homes" state (the config entry was created by selecting
+                # one of this account's homes). Reporting success with empty
+                # data would let platform setup run with zero modules and
+                # destructively clean up registered entities (issue #68).
+                self._consecutive_transient_errors += 1
+                if (
+                    self.data
+                    and self.data.get("modules")
+                    and self._consecutive_transient_errors < MAX_CONSECUTIVE_TRANSIENT_ERRORS
+                ):
+                    _LOGGER.warning(
+                        "Topology returned no homes, keeping last known data (%d/%d).",
+                        self._consecutive_transient_errors,
+                        MAX_CONSECUTIVE_TRANSIENT_ERRORS,
+                    )
+                    return self.data
+                raise UpdateFailed("No homes found for this account (empty topology)")
             if self.home_id not in self.account.homes:
                 raise UpdateFailed(f"Selected home_id {self.home_id} not found in account topology.")
 
@@ -241,6 +252,11 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
             self._consecutive_transient_errors = 0
             return final_data
 
+        except UpdateFailed:
+            # Already a coordinator failure (empty topology, missing home or
+            # bridge) — don't let the generic handler re-wrap it as
+            # "Unexpected error" with a full traceback.
+            raise
         except AuthError as err:
             # Auth errors are critical — must re-authenticate
             raise UpdateFailed(f"Authentication error: {err}") from err

--- a/custom_components/bticino_intercom/utils.py
+++ b/custom_components/bticino_intercom/utils.py
@@ -69,6 +69,17 @@ def cleanup_orphaned_entities(
     Call this after building the entity list but before async_add_entities,
     so that stale entities from previous versions are automatically cleaned up.
     """
+    if not current_entities:
+        # Zero entities at setup almost always means a degraded cloud
+        # response (empty/partial topology), not real module removal.
+        # Removing here would permanently delete the user's registered
+        # entities on one bad boot (issue #68).
+        _LOGGER.warning(
+            "Skipping orphaned-entity cleanup for %s: no entities were created this setup",
+            domain,
+        )
+        return
+
     current_unique_ids = {e.unique_id for e in current_entities}
     ent_reg = er.async_get(hass)
     for reg_entry in er.async_entries_for_config_entry(ent_reg, entry_id):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -773,3 +773,42 @@ class TestTransientErrorTracking:
 
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()
+
+
+# =============================================================================
+# Empty topology handling (issue #68)
+# =============================================================================
+
+
+class TestEmptyTopology:
+    """An empty topology from the cloud must never be reported as success:
+    returning empty data lets platform setup run with zero modules and
+    cleanup_orphaned_entities then permanently deletes registered entities."""
+
+    async def test_empty_homes_without_previous_data_raises(self, coordinator: BticinoIntercomCoordinator) -> None:
+        """At first refresh (no previous data), empty homes must raise UpdateFailed."""
+        coordinator.data = {"homes": {}, "modules": {}, "last_event": {}, "events_history": {}}
+        coordinator.account.homes = {}
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    async def test_empty_homes_with_previous_data_returns_stale(self, coordinator: BticinoIntercomCoordinator) -> None:
+        """A single empty-topology response keeps last known data."""
+        coordinator.account.homes = {}
+
+        result = await coordinator._async_update_data()
+
+        assert result is coordinator.data
+        assert coordinator._consecutive_transient_errors == 1
+
+    async def test_sustained_empty_homes_raise_update_failed(self, coordinator: BticinoIntercomCoordinator) -> None:
+        """Repeated empty-topology responses eventually surface as UpdateFailed."""
+        coordinator.account.homes = {}
+
+        for _ in range(MAX_CONSECUTIVE_TRANSIENT_ERRORS - 1):
+            result = await coordinator._async_update_data()
+            assert result is coordinator.data
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from pybticino.exceptions import ApiError, AuthError
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -95,6 +96,47 @@ async def test_setup_entry_api_failure(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_empty_topology_at_boot_keeps_entities_and_retries(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_auth_handler: AsyncMock,
+    mock_account: AsyncMock,
+    mock_websocket_client: AsyncMock,
+    mock_signaling_client: AsyncMock,
+) -> None:
+    """Regression test for issue #68.
+
+    A transient empty topology at startup must NOT delete previously
+    registered entities: setup has to fail with ConfigEntryNotReady
+    (SETUP_RETRY) instead of proceeding with zero modules and letting
+    cleanup_orphaned_entities wipe the registry.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    # A lock entity registered by a previous healthy boot
+    ent_reg = er.async_get(hass)
+    lock_unique_id = f"{mock_config_entry.entry_id}_lock_d9a63b-a06f-2ef633a2f785"
+    lock_entry = ent_reg.async_get_or_create("lock", DOMAIN, lock_unique_id, config_entry=mock_config_entry)
+
+    # This boot, the cloud returns an empty topology
+    mock_account.homes = {}
+
+    with (
+        patch("custom_components.bticino_intercom.AuthHandler", return_value=mock_auth_handler),
+        patch("custom_components.bticino_intercom.AsyncAccount", return_value=mock_account),
+        patch("custom_components.bticino_intercom.WebsocketClient", return_value=mock_websocket_client),
+        patch("custom_components.bticino_intercom.SignalingClient", return_value=mock_signaling_client),
+        patch("custom_components.bticino_intercom.Store") as mock_store_cls,
+    ):
+        mock_store_cls.return_value.async_load = AsyncMock(return_value=None)
+        mock_store_cls.return_value.async_save = AsyncMock()
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert ent_reg.async_get(lock_entry.entity_id) is not None
 
 
 async def test_unload_entry(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,67 @@
+"""Tests for utility functions (cleanup_orphaned_entities)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bticino_intercom.const import DOMAIN
+from custom_components.bticino_intercom.utils import cleanup_orphaned_entities
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture
+def registered_lock(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> er.RegistryEntry:
+    """Register a lock entity as if created by a previous healthy setup."""
+    mock_config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    return ent_reg.async_get_or_create(
+        "lock",
+        DOMAIN,
+        f"{mock_config_entry.entry_id}_lock_module1",
+        config_entry=mock_config_entry,
+    )
+
+
+async def test_cleanup_removes_stale_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    registered_lock: er.RegistryEntry,
+) -> None:
+    """An entity whose unique_id is no longer built must be removed."""
+    current = [MagicMock(unique_id=f"{mock_config_entry.entry_id}_lock_module2")]
+
+    cleanup_orphaned_entities(hass, mock_config_entry.entry_id, "lock", current)
+
+    assert er.async_get(hass).async_get(registered_lock.entity_id) is None
+
+
+async def test_cleanup_keeps_current_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    registered_lock: er.RegistryEntry,
+) -> None:
+    """An entity rebuilt in the current setup pass must survive cleanup."""
+    current = [MagicMock(unique_id=registered_lock.unique_id)]
+
+    cleanup_orphaned_entities(hass, mock_config_entry.entry_id, "lock", current)
+
+    assert er.async_get(hass).async_get(registered_lock.entity_id) is not None
+
+
+async def test_cleanup_skipped_when_no_entities_created(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    registered_lock: er.RegistryEntry,
+) -> None:
+    """Zero entities built means degraded cloud data, not module removal (issue #68).
+
+    Cleanup must be skipped entirely so a transient empty/partial topology
+    at startup cannot permanently delete the user's registered entities.
+    """
+    cleanup_orphaned_entities(hass, mock_config_entry.entry_id, "lock", [])
+
+    assert er.async_get(hass).async_get(registered_lock.entity_id) is not None


### PR DESCRIPTION
Fixes #68

## Problem

One bad cloud response at boot could permanently delete the user's lock, doorbell, camera and event entities from the registry. Two things combined to make it happen:

1. When `account.homes` came back empty, the coordinator returned *success* with empty `modules` instead of failing, so setup proceeded with no modules at all.
2. Every platform's `cleanup_orphaned_entities()` then removed every registered entity of its domain, since none of the unique_ids had been rebuilt.

The report in #68 is accurate on both points — thanks @politoleo for the excellent analysis.

## Fix

Both suggested changes, as defense in depth:

- **`utils.py`**: cleanup is skipped entirely when the platform built zero entities. An empty list at setup almost always means degraded cloud data, not real module removal. This also covers the *partial* topology case (bridge present, sub-modules missing), which the coordinator check alone can't catch. A warning is logged.
- **`coordinator.py`**: an empty topology is no longer reported as success. It goes through the same transient-failure policy as API errors: keep last known data for the first few occurrences at runtime, raise `UpdateFailed` otherwise — so at first setup it becomes `ConfigEntryNotReady` and HA retries instead of running destructively.
- Minor: `UpdateFailed` raised inside the update path is now re-raised as-is instead of being caught by the generic handler and logged as "Unexpected error" with a full traceback.

## Tests

- `tests/test_utils.py` (new): cleanup removes stale entities, keeps current ones, and skips when zero entities were built.
- `tests/test_coordinator.py`: empty-homes handling (raise at boot, stale data at runtime, `UpdateFailed` after sustained failures).
- `tests/test_init.py`: end-to-end regression of the exact #68 scenario — pre-registered lock entity + empty topology at boot → entry goes to `SETUP_RETRY` and the entity survives.

All 5 new regression tests fail on `main` and pass with this fix; full suite: 196 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)