### PR TITLE
fix: harden WebSocket reconnect lifecycle

### DIFF
--- a/custom_components/bticino_intercom/__init__.py
+++ b/custom_components/bticino_intercom/__init__.py
@@ -82,6 +82,20 @@ def _next_websocket_retry(
     return attempt + 1, base_delay, stable
 
 
+async def _wait_for_websocket_listener(listener_task: asyncio.Task[None], timeout: float) -> bool:
+    """Wait for the listener without creating an orphaned shield future.
+
+    Return ``False`` when the timeout expires. If the listener finishes, await
+    it so its result or exception is consumed exactly once by the manager.
+    """
+    done, _ = await asyncio.wait({listener_task}, timeout=timeout)
+    if listener_task not in done:
+        return False
+
+    await listener_task
+    return True
+
+
 async def _deferred_start_websocket(hass, entry, start_fn):
     """Wait for the config entry to finish loading, then start the WebSocket manager."""
     for _ in range(30):
@@ -296,28 +310,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         # Monitor loop: check stale WS + proactive re-subscribe
                         _LOGGER.debug("Waiting for WebSocket listener task to complete...")
                         last_resubscribe = asyncio.get_running_loop().time()
-                        while not listener_task.done():
-                            try:
-                                await asyncio.wait_for(asyncio.shield(listener_task), timeout=60)
-                            except TimeoutError:
-                                # Proactive re-subscribe to keep session alive
-                                elapsed = asyncio.get_running_loop().time() - last_resubscribe
-                                if elapsed >= TOKEN_RESUBSCRIBE_INTERVAL:
-                                    try:
-                                        _LOGGER.info("Re-subscribing with fresh token (%.0fs elapsed)...", elapsed)
-                                        await websocket_client.resubscribe()
-                                        last_resubscribe = asyncio.get_running_loop().time()
-                                        _LOGGER.info("Re-subscribe successful, connection kept alive.")
-                                    except Exception:
-                                        _LOGGER.warning("Re-subscribe failed, forcing reconnect.", exc_info=True)
-                                        listener_task.cancel()
-                                        with suppress(asyncio.CancelledError):
-                                            await listener_task
-                                        break
-                            except asyncio.CancelledError:
-                                raise
-                        else:
-                            _LOGGER.info("WebSocket listener task finished cleanly.")
+                        while True:
+                            listener_finished = await _wait_for_websocket_listener(listener_task, timeout=60)
+                            if listener_finished:
+                                _LOGGER.info("WebSocket listener task finished cleanly.")
+                                break
+
+                            # Proactive re-subscribe to keep session alive
+                            elapsed = asyncio.get_running_loop().time() - last_resubscribe
+                            if elapsed >= TOKEN_RESUBSCRIBE_INTERVAL:
+                                try:
+                                    _LOGGER.info("Re-subscribing with fresh token (%.0fs elapsed)...", elapsed)
+                                    await websocket_client.resubscribe()
+                                    last_resubscribe = asyncio.get_running_loop().time()
+                                    _LOGGER.info("Re-subscribe successful, connection kept alive.")
+                                except Exception:
+                                    _LOGGER.warning("Re-subscribe failed, forcing reconnect.", exc_info=True)
+                                    listener_task.cancel()
+                                    with suppress(asyncio.CancelledError):
+                                        await listener_task
+                                    break
                     else:
                         _LOGGER.warning("Could not get listener task after connect. Treating as disconnection.")
 

--- a/custom_components/bticino_intercom/__init__.py
+++ b/custom_components/bticino_intercom/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import random
 from contextlib import suppress
 
 import websockets  # Import websockets for exception handling
@@ -41,10 +42,11 @@ from .media_source import BticinoHistoryImageView
 
 _LOGGER = logging.getLogger(__name__)
 
-RECONNECT_DELAY = 30  # Default delay, overridden by smart backoff
 BOOT_RETRY_DELAYS = [5, 10, 30, 30, 30, 60]  # Backoff al boot
 RUNTIME_RETRY_DELAYS = [5, 15, 30, 60, 120]  # Backoff durante vita normale
 MAX_CONSECUTIVE_WS_FAILURES = 5  # Force config entry reload after this many consecutive failures
+WS_STABLE_CONNECTION_SECONDS = 300  # A shorter connection still counts as a failed retry
+RECONNECT_JITTER_RATIO = 0.2  # Avoid reconnecting every client at the same instant
 TOKEN_RESUBSCRIBE_INTERVAL = 3600  # Re-subscribe with fresh token every hour
 WEBSOCKET_TASK_KEY = "websocket_connection_task"
 WEBSOCKET_CLIENT_KEY = "websocket_client"
@@ -55,6 +57,29 @@ START_LISTENER_REMOVE_KEY = "start_listener_remove"
 HISTORY_KEY = "history"
 HISTORY_VIEW_FLAG = f"{DOMAIN}_history_view_registered"
 TOKEN_STORAGE_VERSION = 1
+
+
+def _next_websocket_retry(
+    *,
+    attempt: int,
+    is_boot: bool,
+    session_duration: float | None,
+    received_message: bool,
+) -> tuple[int, int, bool]:
+    """Return the next failure count, base delay, and session stability.
+
+    Completing a WebSocket handshake isn't enough to prove recovery: a cloud
+    endpoint can briefly accept a connection and close it again moments later.
+    Only a sufficiently long session or real application traffic resets the
+    consecutive-failure counter.
+    """
+    stable = received_message or (session_duration is not None and session_duration >= WS_STABLE_CONNECTION_SECONDS)
+    if stable:
+        attempt = 0
+
+    delays = BOOT_RETRY_DELAYS if is_boot else RUNTIME_RETRY_DELAYS
+    base_delay = delays[min(attempt, len(delays) - 1)]
+    return attempt + 1, base_delay, stable
 
 
 async def _deferred_start_websocket(hass, entry, start_fn):
@@ -254,13 +279,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     entry.state,
                 )
                 listener_task = None
+                connection_started_at = None
+                message_time_at_connect = None
                 try:
                     # Attempt to connect (includes subscription and starting listener)
                     _LOGGER.info("Attempting WebSocket connect... (calling websocket_client.connect)")
+                    message_time_at_connect = coordinator.last_ws_message_time
                     await websocket_client.connect()
                     _LOGGER.info("WebSocket connect call completed without raising immediate exception.")
-                    # Connection succeeded: reset retry state
-                    attempt = 0
+                    connection_started_at = asyncio.get_running_loop().time()
                     is_boot = False
 
                     # Get the listener task from the client
@@ -273,16 +300,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             try:
                                 await asyncio.wait_for(asyncio.shield(listener_task), timeout=60)
                             except TimeoutError:
-                                # Check if coordinator flagged WS as stale
-                                if coordinator.ws_stale:
-                                    _LOGGER.warning("WebSocket flagged as stale by coordinator, forcing reconnect")
-                                    coordinator._ws_stale = False
-                                    coordinator._last_ws_message_time = None
-                                    listener_task.cancel()
-                                    with suppress(asyncio.CancelledError):
-                                        await listener_task
-                                    break
-
                                 # Proactive re-subscribe to keep session alive
                                 elapsed = asyncio.get_running_loop().time() - last_resubscribe
                                 if elapsed >= TOKEN_RESUBSCRIBE_INTERVAL:
@@ -319,16 +336,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     websockets.exceptions.WebSocketException,
                 ) as err:
                     _LOGGER.warning(
-                        "WebSocket connection error (%s): %s. Retrying in %d seconds...",
+                        "WebSocket connection error (%s): %s. Scheduling reconnect.",
                         type(err).__name__,
                         err,
-                        RECONNECT_DELAY,
                     )
                 except Exception:
                     # Catch-all for other unexpected errors during connect/listen
                     _LOGGER.exception(
-                        "Unexpected error in WebSocket connection manager during connect/listen. Retrying in %d seconds...",
-                        RECONNECT_DELAY,
+                        "Unexpected error in WebSocket connection manager during connect/listen. Scheduling reconnect."
                     )
                 finally:  # Finally for the inner try (connect/listen attempt)
                     # Ensure disconnect is called before retrying or exiting this attempt
@@ -346,10 +361,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # --- Smart Reconnect Delay Logic ---
                 _LOGGER.debug("WebSocket manager: Reached reconnect delay logic.")
                 if hass.is_running and entry.state == config_entries.ConfigEntryState.LOADED:
-                    # Pick delay from appropriate backoff schedule
-                    delays = BOOT_RETRY_DELAYS if is_boot else RUNTIME_RETRY_DELAYS
-                    delay = delays[min(attempt, len(delays) - 1)]
-                    attempt += 1
+                    session_duration = (
+                        asyncio.get_running_loop().time() - connection_started_at
+                        if connection_started_at is not None
+                        else None
+                    )
+                    received_message = (
+                        connection_started_at is not None
+                        and coordinator.last_ws_message_time != message_time_at_connect
+                    )
+                    attempt, base_delay, stable = _next_websocket_retry(
+                        attempt=attempt,
+                        is_boot=is_boot,
+                        session_duration=session_duration,
+                        received_message=received_message,
+                    )
+
+                    if stable:
+                        _LOGGER.info(
+                            "WebSocket session was healthy (duration=%.0fs, message_received=%s); "
+                            "resetting reconnect backoff.",
+                            session_duration or 0,
+                            received_message,
+                        )
 
                     # After too many consecutive failures, force a full
                     # config entry reload to reset all state cleanly.
@@ -361,11 +395,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         hass.config_entries.async_schedule_reload(entry.entry_id)
                         break
 
+                    jitter = random.uniform(0, base_delay * RECONNECT_JITTER_RATIO)
+                    delay = base_delay + jitter
+
                     _LOGGER.info(
-                        "WebSocket reconnect attempt %d (%s), waiting %ds...",
+                        "WebSocket reconnect attempt %d (%s), waiting %.1fs (base=%ds)...",
                         attempt,
                         "boot" if is_boot else "runtime",
                         delay,
+                        base_delay,
                     )
                     try:
                         await asyncio.sleep(delay)

--- a/custom_components/bticino_intercom/coordinator.py
+++ b/custom_components/bticino_intercom/coordinator.py
@@ -38,13 +38,6 @@ from .const import (
 )
 from .history import EventHistoryStore
 
-# WebSocket is considered stale if no application message has been received
-# for this many seconds.  Note: _last_ws_message_time only updates on data
-# frames reaching the message callback — protocol-level WS pings do not count.
-# 300s keeps detection reasonably fast without flagging quiet-but-healthy
-# connections during idle periods.
-WS_STALE_THRESHOLD = 300  # 5 minutes
-
 # After this many consecutive transient API failures, raise UpdateFailed
 # instead of returning stale data, so entities are properly marked unavailable.
 MAX_CONSECUTIVE_TRANSIENT_ERRORS = 3
@@ -87,7 +80,6 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
         self._normalized_home_name = None
         self._main_device_id = None
         self._last_ws_message_time: datetime | None = None
-        self._ws_stale = False
         self._consecutive_transient_errors = 0
         # Per-module active call sessions for retransmission dedup.
         # {"started": datetime, "last_seen": datetime,
@@ -235,18 +227,6 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
             if "name" in final_data["homes"][self.home_id]:
                 self._home_name = final_data["homes"][self.home_id]["name"]
                 _LOGGER.debug("Home name set to: %s", self._home_name)
-
-            # Check WebSocket health: if we haven't received a message in a while,
-            # flag the connection as stale so the manager can force a reconnect.
-            if self._last_ws_message_time:
-                silence = (datetime.now(UTC) - self._last_ws_message_time).total_seconds()
-                if silence > WS_STALE_THRESHOLD:
-                    _LOGGER.warning(
-                        "WebSocket has been silent for %ds (threshold %ds), flagging as stale",
-                        int(silence),
-                        WS_STALE_THRESHOLD,
-                    )
-                    self._ws_stale = True
 
             # Successful update: reset transient error counter
             self._consecutive_transient_errors = 0
@@ -757,14 +737,13 @@ class BticinoIntercomCoordinator(DataUpdateCoordinator):
             raise
 
     @property
-    def ws_stale(self) -> bool:
-        """Return True if the WebSocket connection appears stale."""
-        return self._ws_stale
+    def last_ws_message_time(self) -> datetime | None:
+        """Return when the last application-level WebSocket message arrived."""
+        return self._last_ws_message_time
 
     async def _handle_websocket_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages."""
         self._last_ws_message_time = datetime.now(UTC)
-        self._ws_stale = False
         _LOGGER.debug("Coordinator: _handle_websocket_message called with: %s", message)
         data_updated = await self._process_websocket_event(message)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Tests for BTicino integration setup and unload."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from custom_components.bticino_intercom import (
     RUNTIME_RETRY_DELAYS,
     WS_STABLE_CONNECTION_SECONDS,
     _next_websocket_retry,
+    _wait_for_websocket_listener,
 )
 from custom_components.bticino_intercom.const import DOMAIN
 
@@ -79,6 +81,25 @@ def test_failed_boot_connection_uses_boot_backoff() -> None:
     assert attempt == 2
     assert delay == 10
     assert stable is False
+
+
+async def test_listener_timeout_then_exception_is_consumed_by_manager() -> None:
+    """A polling timeout must not leave a shield future with an unhandled error."""
+    release_listener = asyncio.Event()
+
+    async def _listener() -> None:
+        await release_listener.wait()
+        raise RuntimeError("listener failed")
+
+    listener_task = asyncio.create_task(_listener())
+
+    assert await _wait_for_websocket_listener(listener_task, timeout=0) is False
+
+    release_listener.set()
+    with pytest.raises(RuntimeError, match="listener failed"):
+        await _wait_for_websocket_listener(listener_task, timeout=1)
+
+    assert listener_task.done()
 
 
 async def test_setup_entry_success(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,11 +12,73 @@ from pytest_homeassistant_custom_component.common import (
     async_capture_events,
 )
 
+from custom_components.bticino_intercom import (
+    RUNTIME_RETRY_DELAYS,
+    WS_STABLE_CONNECTION_SECONDS,
+    _next_websocket_retry,
+)
 from custom_components.bticino_intercom.const import DOMAIN
 
 from .conftest import EXTERNAL_UNIT_ID, HOME_ID, _setup_integration
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+def test_short_websocket_sessions_keep_escalating_backoff() -> None:
+    """A successful handshake followed by a quick close is still a failure."""
+    attempt = 0
+
+    for expected_attempt, expected_delay in enumerate(RUNTIME_RETRY_DELAYS, start=1):
+        attempt, delay, stable = _next_websocket_retry(
+            attempt=attempt,
+            is_boot=False,
+            session_duration=WS_STABLE_CONNECTION_SECONDS - 1,
+            received_message=False,
+        )
+
+        assert attempt == expected_attempt
+        assert delay == expected_delay
+        assert stable is False
+
+    assert attempt == 5
+
+
+@pytest.mark.parametrize(
+    ("session_duration", "received_message"),
+    [
+        (WS_STABLE_CONNECTION_SECONDS, False),
+        (1, True),
+    ],
+)
+def test_healthy_websocket_session_resets_backoff(
+    session_duration: float,
+    received_message: bool,
+) -> None:
+    """A stable session or real message re-arms the shortest retry delay."""
+    attempt, delay, stable = _next_websocket_retry(
+        attempt=4,
+        is_boot=False,
+        session_duration=session_duration,
+        received_message=received_message,
+    )
+
+    assert attempt == 1
+    assert delay == RUNTIME_RETRY_DELAYS[0]
+    assert stable is True
+
+
+def test_failed_boot_connection_uses_boot_backoff() -> None:
+    """A connection that never completed keeps the boot retry schedule."""
+    attempt, delay, stable = _next_websocket_retry(
+        attempt=1,
+        is_boot=True,
+        session_duration=None,
+        received_message=False,
+    )
+
+    assert attempt == 2
+    assert delay == 10
+    assert stable is False
 
 
 async def test_setup_entry_success(


### PR DESCRIPTION
## Summary

- stop treating an idle-but-healthy WebSocket as stale based only on application-message silence
- keep consecutive reconnect failures until a session is stable or receives real traffic
- add reconnect jitter while retaining the existing boot/runtime backoff schedules
- consume listener task exceptions directly, avoiding orphaned shield futures and duplicate Home Assistant errors

## Why

The connection manager previously reset its retry counter immediately after a successful handshake. When the cloud accepted a connection and closed it shortly afterwards, retries could loop without escalating.

The coordinator watchdog also treated five minutes without application messages as a stale connection, even though protocol-level ping/pong traffic does not reach the message callback.

Polling the listener with `wait_for(shield(task))` could additionally leave a timed-out shield wrapper that later surfaced `ConnectionClosedError` as an unhandled Home Assistant future.

## Validation

- `ruff format --check .`
- `ruff check .`
- 201 tests passed
- tested on Home Assistant with BTicino Classe 300EOS
- repeated real-world code 1006 disconnects and HTTP 503 subscription failures triggered the expected reconnect path
- after recovery, a real `incoming_call` followed by `accepted_call` was received with about one second of state-update latency
- the previous `exception in shielded future` error did not recur

The unrelated Bridge Last Boot timestamp jitter is intentionally left out of this PR.